### PR TITLE
[43기 김수현]ADD: 유저 API 기능 구현

### DIFF
--- a/api/controllers/index.js
+++ b/api/controllers/index.js
@@ -1,8 +1,10 @@
+const userController = require("./userController");
 const itemController = require("./itemController");
 const orderController = require("./orderController");
 const wishlistController = require("./wishlistController");
 
 module.exports = {
+  userController,
   itemController,
   orderController,
   wishlistController

--- a/api/controllers/userController.js
+++ b/api/controllers/userController.js
@@ -1,0 +1,37 @@
+const {userService} = require("../services");
+const {catchAsync} = require("../utils/error");
+
+const kakaoSignIn = catchAsync(async (req, res) => {
+    const {code} = req.query;
+    if (!code) {
+        res.status(200).json({message: "KEY_ERROR"});
+    }
+    const result = await userService.login(code);
+    res.status(200).json({result});
+})
+
+const getUser = catchAsync(async (req, res) => {
+    const userId = req.user
+    const user = await userService.getUser(userId);
+    res.status(200).json({user});
+})
+
+const registerBuyer = catchAsync(async (req, res) => {
+    const userId = req.user
+    await userService.registerBuyer(userId);
+    res.status(201).json({message: "SUCCESSFULLY_REGISTERED"});
+})
+
+const registerSeller = catchAsync(async (req, res) => {
+    const userId = req.user
+    const {bankName, bankAccount, artistRegistration} = req.body
+    await userService.registerSeller(userId, bankName, bankAccount, artistRegistration);
+    res.status(201).json({message: "SUCCESSFULLY_REGISTERED"});
+})
+
+module.exports = {
+    kakaoSignIn,
+    getUser,
+    registerBuyer,
+    registerSeller,
+};

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -1,11 +1,15 @@
+const appDataSource = require("./dataSource");
 const dataSource = require("./dataSource");
+const userDao = require("./userDao");
 const itemDao = require("./itemDao");
 const bidDao = require("./bidDao");
 const orderDao = require("./orderDao");
 const wishlistDao = require("./wishlistDao");
 
 module.exports = {
+  appDataSource,
   dataSource,
+  userDao,
   itemDao,
   bidDao,
   orderDao,

--- a/api/models/userDao.js
+++ b/api/models/userDao.js
@@ -1,0 +1,62 @@
+const dataSource = require("./dataSource");
+
+const getUser = async (userId) => {
+    return await dataSource.query(`
+      SELECT id,
+             email,
+             name,
+             CONCAT(bank_name, "은행")        AS bankName,
+             bank_account                   AS bankAccount,
+             artist_registration            AS artistRegistration,
+             IF(bid_agreement, "동의", "비동의") AS bidAgreement,
+             CONCAT(YEAR(created_at), "년 ", MONTH(created_at), "월 ", DAY(created_at), "일 ",
+                    HOUR(created_at), "시 ", MINUTE(created_at), "분 ", SECOND(created_at),
+                    "초")                    AS createdAt
+      FROM users
+      WHERE id = ?`, [userId])
+}
+
+const registerBuyer = async (userId) => {
+    await dataSource.query(`
+      UPDATE users
+      SET bid_agreement = 1
+      WHERE id = ?`, [userId])
+}
+
+const registerSeller = async (userId, bankName, bankAccount, artistRegistration) => {
+    await dataSource.query(`
+      UPDATE users
+      SET bank_name           = ?,
+          bank_account        = ?,
+          artist_registration = ?
+      WHERE id = ?`, [bankName, bankAccount, artistRegistration, userId])
+}
+
+const checkRegistered = async (kakaoId) => {
+    const [res] = await dataSource.query(`
+      SELECT EXISTS(
+                     SELECT id FROM users WHERE provider_id = ?) AS registered`, [kakaoId])
+    return !!parseInt(res["registered"])
+}
+
+const createKakaoUser = async (kakaoId, email, nickname) => {
+    await dataSource.query(`INSERT INTO users(email, name, provider_id)
+                          VALUES (?, ?, ?)`, [email, nickname, kakaoId])
+}
+
+const getUserBySocialId = async (kakaoId) => {
+    return await dataSource.query(
+      `SELECT id as userId
+     FROM users
+     WHERE provider_id = ?`, [kakaoId]
+    )
+}
+
+module.exports = {
+    getUser,
+    registerBuyer,
+    registerSeller,
+    checkRegistered,
+    createKakaoUser,
+    getUserBySocialId,
+};

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,11 +1,13 @@
 const express = require("express");
 
+const userRouter = require("./userRouter");
 const itemRouter = require("./itemRouter");
 const orderRouter = require("./orderRouter");
 const wishlistRouter = require("./wishlistRouter");
 
 const router = express.Router();
 
+router.use("/users", userRouter);
 router.use("/items", itemRouter);
 router.use("/orders", orderRouter);
 router.use("/wishlist", wishlistRouter);

--- a/api/routes/userRouter.js
+++ b/api/routes/userRouter.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { userController } = require("../controllers");
+const {loginRequired} = require("../utils/auth");
+
+const router = express.Router();
+
+router.get("/auth/kakao/callback", userController.kakaoSignIn);
+router.get("", loginRequired, userController.getUser);
+router.patch("/buyer", loginRequired, userController.registerBuyer);
+router.patch("/seller", loginRequired, userController.registerSeller);
+
+module.exports = router;
+

--- a/api/services/index.js
+++ b/api/services/index.js
@@ -1,8 +1,10 @@
+const userService = require("./userService");
 const itemService = require("./itemService");
 const orderService = require("./orderService");
 const wishlistService = require("./wishlistService");
 
 module.exports = {
+  userService,
   itemService,
   orderService,
   wishlistService

--- a/api/services/userService.js
+++ b/api/services/userService.js
@@ -1,0 +1,77 @@
+const {userDao} = require("../models");
+const jwt = require('jsonwebtoken');
+const axios = require('axios');
+
+const login = async (code) => {
+  const getToken = await axios.post("https://kauth.kakao.com/oauth/token",
+    {
+      grant_type: "authorization_code",
+      client_id: process.env.CLIENT_ID,
+      redirect_uri: "http://localhost:3000/auth/kakao/callback",
+      code: code
+    },
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
+      }
+    });
+
+  const accessToken = getToken.data.access_token
+
+  const getKakaoUserData = await axios.get(
+    `https://kapi.kakao.com/v2/user/me`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }
+  );
+
+  const {id: kakaoId, properties: {nickname}, kakao_account: {email}} = getKakaoUserData.data;
+
+  const isExist = await userDao.checkRegistered(kakaoId);
+
+  let response = {
+    accessToken: '',
+    statusCode: 0,
+  }
+
+  const jwtAccessToken = (Object, statusCode) => {
+    response.accessToken = jwt.sign(Object, process.env.JWT_SECRET, {
+      algorithm: process.env.JWT_ALGORITHM,
+      expiresIn: process.env.JWT_EXPIRES_IN,
+    })
+    response.statusCode = statusCode;
+    return [response.accessToken, response.statusCode]
+  }
+  const [userId] = await userDao.getUserBySocialId(kakaoId);
+
+  if (!isExist) {
+    await userDao.createKakaoUser(kakaoId, email, nickname)
+    jwtAccessToken({userId: kakaoId})
+  } else {
+    jwtAccessToken({userId: userId.userId})
+  }
+
+  return response;
+};
+
+const getUser = async (userId) => {
+  return await userDao.getUser(userId);
+};
+
+const registerBuyer = async (userId) => {
+  return await userDao.registerBuyer(userId);
+};
+
+const registerSeller = async (userId, bankName, bankAccount, artistRegistration) => {
+  return await userDao.registerSeller(userId, bankName, bankAccount, artistRegistration);
+};
+
+module.exports = {
+  login,
+  getUser,
+  registerBuyer,
+  registerSeller,
+};

--- a/api/utils/auth.js
+++ b/api/utils/auth.js
@@ -1,0 +1,22 @@
+const jwt = require("jsonwebtoken");
+const {catchAsync} = require("./error");
+
+const loginRequired = catchAsync(async (req, res, next) => {
+    const accessToken = req.headers.authorization;
+
+    if (!accessToken) {
+        const error = new Error("NEED_ACCESS_TOKEN");
+        return res.status(401).json({message: error.message});
+    }
+
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET);
+
+    if (!decoded.userId) {
+        const error = new Error("USER_DOES_NOT_EXIST");
+        return res.status(404).json({message: error.message});
+    }
+    req.user = decoded.userId;
+    next();
+})
+
+module.exports = {loginRequired};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 카카오 소셜 로그인 기능 구현
- 마이페이지 유저 정보 조회 기능 구현
- 마이페이지 구매자 등록 기능 구현
- 마이페이지 판매자 등록 기능 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 카카오 소셜 로그인 시 인가코드를 받아 카카오에 토큰 요청, 토큰을 받아 jwt토큰을 생성하여 클라이언트에 송신 후, 데이터 베이스에 해시된 패스워드를 저장
- 데이터베이스에 없는 회원일 경우 자동 회원가입

<br />

## :: 테스트 결과 이미지
![카카오 소셜 로그인](https://user-images.githubusercontent.com/110106750/229392293-d966e10f-084c-486e-ae8d-b5c723c81608.png)


<br />

## :: 기타 질문 및 특이 사항
- 제가 작성한 함수의 로직을 구현할 더 좋은 방법이 있으면 좋겠습니다.
